### PR TITLE
Change to use the LGPL version of iTextSharp

### DIFF
--- a/RazorPDF/PdfResult.cs
+++ b/RazorPDF/PdfResult.cs
@@ -12,11 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
+
 using System.Web.Mvc;
 
 namespace RazorPDF

--- a/RazorPDF/PdfView.cs
+++ b/RazorPDF/PdfView.cs
@@ -12,14 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // 
-using System;
-using System.Collections.Generic;
+
 using System.IO;
-using System.Linq;
 using System.Text;
 using System.Web.Mvc;
 using System.Xml;
-using System.Xml.Linq;
 using iTextSharp.text;
 using iTextSharp.text.html;
 using iTextSharp.text.pdf;
@@ -39,8 +36,8 @@ namespace RazorPDF
         public void Render(ViewContext viewContext, TextWriter writer)
         {
             // generate view into string
-            var sb = new System.Text.StringBuilder();
-            TextWriter tw = new System.IO.StringWriter(sb);
+            var sb = new StringBuilder();
+            TextWriter tw = new StringWriter(sb);
             _result.View.Render(viewContext, tw);
             var resultCache = sb.ToString();
 
@@ -82,8 +79,8 @@ namespace RazorPDF
 
         private static XmlTextReader GetXmlReader(string source)
         {
-            byte[] byteArray = Encoding.UTF8.GetBytes(source);
-            MemoryStream stream = new MemoryStream(byteArray);
+            var byteArray = Encoding.UTF8.GetBytes(source);
+            var stream = new MemoryStream(byteArray);
 
             var xtr = new XmlTextReader(stream);
             xtr.WhitespaceHandling = WhitespaceHandling.None; // Helps iTextSharp parse 

--- a/RazorPDF/RazorPDF.csproj
+++ b/RazorPDF/RazorPDF.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>RazorPDF</RootNamespace>
     <AssemblyName>RazorPDF</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
@@ -36,8 +36,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="itextsharp, Version=4.1.2.0, Culture=neutral, PublicKeyToken=8354ae6d2174ddca">
-      <HintPath>..\packages\iTextSharp.4.1.2\lib\itextsharp.dll</HintPath>
+    <Reference Include="iTextSharp">
+      <HintPath>..\packages\iTextSharp-LGPL.4.1.6\lib\iTextSharp.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/RazorPDF/packages.config
+++ b/RazorPDF/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="iTextSharp" version="4.1.2" />
+  <package id="iTextSharp-LGPL" version="4.1.6" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
Change to use the LGPL version of iTextSharp because the main version of
iTextSharp changed its license to AGPL.
